### PR TITLE
Fix feature flaw of history command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,6 +20,8 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_EMPTY_CALL_HISTORY = "This person has no call history";
+    public static final String MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW = "This command is restricted in history view. "
+            + "Use 'list' to return to the person list view to use this command.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -20,8 +20,9 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_EMPTY_CALL_HISTORY = "This person has no call history";
-    public static final String MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW = "This command is restricted in history view. "
-            + "Use 'list' to return to the person list view to use this command.";
+    public static final String MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW = "This command is restricted in history view."
+            + "\nIt is only available in the person list view to ensure the command is executed on the correct person."
+            + "\nUse 'list' to return to the person list view to use this command.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -87,6 +87,11 @@ public class DeleteCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
             }
         }
+
+        if (model.isHistoryView()) {
+            throw new CommandException(Messages.MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW);
+        }
+
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -146,6 +146,10 @@ public class EditCommand extends Command {
             finalMessage = String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
         }
 
+        if (model.isHistoryView()) {
+            throw new CommandException(Messages.MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW);
+        }
+
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -101,6 +101,11 @@ public class MarkCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
             }
         }
+
+        if (model.isHistoryView()) {
+            throw new CommandException(Messages.MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW);
+        }
+
         model.markAsContacted(personToMark, contactRecord);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_MARK_PERSON_SUCCESS,

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -82,6 +82,18 @@ public interface Model {
     boolean hasSimilarPerson(Person person, Person exclude);
 
     /**
+     * Returns true if the current view is the history view.
+     */
+    boolean isHistoryView();
+
+    /**
+     * Sets the current view to the history view.
+     *
+     * @param historyView True if the current view is the history view, false otherwise
+     */
+    void setHistoryView(boolean historyView);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -29,6 +29,7 @@ public class ModelManager implements Model {
     private final FilteredList<Person> filteredPersons;
     private final ObservableList<ContactRecord> displayedCallHistory;
     private final CommandTextHistory commandTextHistory;
+    private boolean historyView = false;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -128,7 +129,6 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
     }
 
@@ -163,6 +163,7 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+        setHistoryView(false);
     }
 
     //=========== Call History ================================================================================
@@ -179,6 +180,17 @@ public class ModelManager implements Model {
         for (int i = callHistory.size() - 1; i >= 0; i--) {
             displayedCallHistory.add(callHistory.get(i));
         }
+        setHistoryView(true);
+    }
+
+    @Override
+    public boolean isHistoryView() {
+        return historyView;
+    }
+
+    @Override
+    public void setHistoryView(boolean historyView) {
+        this.historyView = historyView;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -211,6 +211,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean isHistoryView() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setHistoryView(boolean historyView) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addCommandTextToHistory(String commandText) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -173,4 +173,11 @@ public class DeleteCommandTest {
 
         assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
     }
+
+    @Test
+    public void restrictedUsageInHistoryView() {
+        model.setHistoryView(true);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -286,4 +286,12 @@ public class EditCommandTest {
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
     }
+
+    @Test
+    public void restrictedUsageInHistoryView() {
+        model.setHistoryView(true);
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -190,4 +190,12 @@ public class MarkCommandTest {
 
         assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_NRIC);
     }
+
+    @Test
+    public void restrictedUsageInHistoryView() {
+        model.setHistoryView(true);
+        ContactRecord validRecord = new ContactRecordBuilder().build();
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, validRecord);
+        assertCommandFailure(markCommand, model, Messages.MESSAGE_USAGE_RESTRICTED_IN_HISTORY_VIEW);
+    }
 }


### PR DESCRIPTION
- Restrict the usage of data-modifying commands such as 'delete', 'mark' and 'edit' when user is in history view to prevent unintended changes
- For other commands such as 'find', 'history' and 'add' are still executable in history view as they do not alter the existing data ('add' is still accessable as it does not depend on the person list)

closes https://github.com/AY2425S1-CS2103T-F14b-3/tp/issues/107
