### PR TITLE
Fix misc bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -103,7 +103,8 @@ Edits an existing elderly in ContactMate.
 Format: `edit INDEX/NRIC [i/NRIC] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/CALL_FREQUENCY] [t/TAG]…​`
 
 * Edits the elderly at the specified `INDEX` or `NRIC`. The index refers to the index number shown in the displayed person list. The index must be within the range of list shown and **must be a positive integer** 1, 2, 3, …​
-* The `NRIC` has to be a valid NRIC.
+* Both `NRIC`'s must be a valid, government issued NRIC.
+* The `NRIC` used to select the elderly to edit must exist in the person list.
 * At least one of the optional fields must be provided.
 * The existing values will be replaced with the new input values.
 * When editing tags, the existing tags of the elderly will be removed i.e adding of tags is not cumulative.
@@ -143,7 +144,8 @@ Format: `delete INDEX/NRIC`
 * Deletes the elderly at the specified `INDEX` or `NRIC`.
 * The index refers to the index number shown in the displayed person list.
 * The index must be within the range of list shown and **must be a positive integer** 1, 2, 3, …​
-* The `NRIC` has to be a valid NRIC
+* `NRIC` must be a valid, government issued NRIC.
+* The `NRIC` used to select the elderly to delete must exist in the person list.
 
 Examples:
 * `list` followed by `delete 2` deletes the 2nd elderly in ContactMate.
@@ -161,7 +163,8 @@ Format: `mark INDEX/NRIC [d/DATE] [o/NOTES]`
 
 * Marks the person at the specified `INDEX` or `NRIC`.
 * The index refers to the index number shown in the displayed person list. The index must be within the range of list shown and **must be a positive integer** 1, 2, 3, …​
-* The `NRIC` has to be a valid NRIC.
+* `NRIC` must be a valid, government issued NRIC.
+* The `NRIC` used to select the elderly to mark must exist in the person list.
 * The date must be in the format `YYYY-MM-DD` and must not be a future date.
 * If the parameter `d/DATE` is not provided, the current date will be used.
 
@@ -179,7 +182,8 @@ Format: `history INDEX/NRIC`
 * Shows the call history of the elderly at the specified `INDEX` or `NRIC`.
 * The index refers to the index number shown in the displayed person list.
 * The index must be within the range of list shown and **must be a positive integer** 1, 2, 3, …​
-* The `NRIC` has to be a valid NRIC
+* `NRIC` must be a valid, government issued NRIC.
+* The `NRIC` used to select the elderly must exist in the person list.
 
 Examples:
 * `list` followed by `history 2` shows the call history of the 2nd elderly in ContactMate.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -179,7 +179,7 @@ Format: `history INDEX/NRIC`
 * Shows the call history of the elderly at the specified `INDEX` or `NRIC`.
 * The index refers to the index number shown in the displayed person list.
 * The index must be within the range of list shown and **must be a positive integer** 1, 2, 3, …​
-* The NRIC has to be a valid NRIC
+* The `NRIC` has to be a valid NRIC
 
 Examples:
 * `list` followed by `history 2` shows the call history of the 2nd elderly in ContactMate.
@@ -204,6 +204,17 @@ Format: `exit`
 
 ### Navigating the Command History
 You are able to navigate through your command history (both valid and invalid commands) by using the up <kbd>&#8593;</kbd> and down <kbd>&#8595;</kbd> arrow keys.
+
+### Duplicate detection
+Duplicate entries (elderly) are entries with the same NRIC (case-insensitive). ContactMate will not allow duplicate entries, and will stop you from adding (`add`) or editing (`edit`) an elderly if it would result in a duplicate entry.
+
+Examples:
+* `edit 1 i/S2208201I` followed by `edit 2 i/s2208201i` will result in an error message, as the NRIC `S2208201I` already exists.
+
+A weaker notion of duplication is that of entries with the same name, phone number or email (all case-insensitive). ContactMate will not prevent you from adding (`add`) or editing (`edit`) an elderly in this case, but will warn you that the entry is a potential duplicate.
+
+Examples:
+* `edit 1 n/John Doe` followed by `edit 2 n/John Doe` will result in a warning message, as the name `John Doe` already exists, but the edit will still be allowed.
 
 ### Saving the data
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -46,7 +46,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_SUCCESS_WITH_WARNING = "New person added: %1$s\n"
             + "Warning: There is an existing person with the same name, phone number or email.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person (Same NRIC) already exists in the address book";
 
     private final Person toAdd;
     /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -61,7 +61,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS_WITH_WARNING = "Edited Person: %1$s\n"
             + "Warning: There is an existing person with the same name, phone number or email.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person (Same NRIC) already exists in the address book.";
 
     private final Index index;
     private final Nric nric;

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -29,8 +29,9 @@ public class MarkCommandParser implements Parser<MarkCommand> {
 
         String preamble = argMultimap.getPreamble();
         String notes = argMultimap.getValue(PREFIX_NOTES).orElse("");
-        ContactRecord contactRecord;
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NOTES, PREFIX_DATE);
+
+        ContactRecord contactRecord;
         if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
             LocalDate date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
             contactRecord = new ContactRecord(date, notes);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,7 +168,11 @@ public class ParserUtil {
         if (!ContactRecord.isValidContactRecord(trimmedDate)) {
             throw new ParseException(ContactRecord.MESSAGE_CONSTRAINTS);
         }
-        return LocalDate.parse(trimmedDate);
+        LocalDate parsedDate = LocalDate.parse(trimmedDate);
+        if (!ContactRecord.isCurrentOrPastDate(parsedDate)) {
+            throw new ParseException(ContactRecord.MESSAGE_CONSTRAINTS_FUTURE_DATE);
+        }
+        return parsedDate;
     }
 
     /**

--- a/src/main/java/seedu/address/model/contactrecord/ContactRecord.java
+++ b/src/main/java/seedu/address/model/contactrecord/ContactRecord.java
@@ -16,8 +16,8 @@ import seedu.address.model.person.CallFrequency;
 public class ContactRecord implements Comparable<ContactRecord> {
     public static final String DATE_FORMAT = "yyyy-MM-dd";
     public static final String MESSAGE_CONSTRAINTS =
-            "Dates should be in the format of " + DATE_FORMAT + " and should not be in the future.";
-    public static final String VALIDATION_REGEX = "\\d{4}-\\d{2}-\\d{2}";
+            "Dates should be valid, and in the format of " + DATE_FORMAT;
+    public static final String MESSAGE_CONSTRAINTS_FUTURE_DATE = "Dates should not be in the future";
     public final LocalDate value;
     private final String notes;
 
@@ -38,18 +38,21 @@ public class ContactRecord implements Comparable<ContactRecord> {
      */
     public static boolean isValidContactRecord(String testDate) {
         try {
-            if (!testDate.matches(VALIDATION_REGEX)) {
-                return false;
-            }
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
-            LocalDate date = LocalDate.parse(testDate, formatter);
-            if (date.isAfter(LocalDate.now())) {
-                return false;
-            }
+            LocalDate.parse(testDate, formatter);
             return true;
         } catch (DateTimeParseException e) {
             return false;
         }
+    }
+
+    /**
+     * Returns true if the given date is a current or past date.
+     *
+     * @param date The date to check.
+     */
+    public static boolean isCurrentOrPastDate(LocalDate date) {
+        return date.isBefore(LocalDate.now()) || date.isEqual(LocalDate.now());
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedContactRecord.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContactRecord.java
@@ -47,6 +47,9 @@ public class JsonAdaptedContactRecord {
             throw new IllegalValueException(ContactRecord.MESSAGE_CONSTRAINTS);
         }
         LocalDate date = LocalDate.parse(this.date);
+        if (!ContactRecord.isCurrentOrPastDate(date)) {
+            throw new IllegalValueException(ContactRecord.MESSAGE_CONSTRAINTS_FUTURE_DATE);
+        }
         if (notes == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "notes"));
         }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -21,7 +21,7 @@ import seedu.address.model.person.Person;
 @JsonRootName(value = "addressbook")
 class JsonSerializableAddressBook {
 
-    public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s) (Same NRIC).";
 
     public static final String MESSAGE_SIMILAR_PERSON = """
             %s

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -54,7 +54,7 @@ public class PersonCard extends UiPart<Region> {
         super(FXML);
         this.person = person;
         id.setText(displayedIndex + ". ");
-        nric.setText(person.getNric().value);
+        nric.setText(person.getNric().value + " - ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -25,29 +25,58 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="nric" styleClass="cell_big_label" text="\$nric" />
-        <Label styleClass="cell_big_label" text=" - " />
+        <Label fx:id="nric" styleClass="cell_big_label" text="\$nric">
+            <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
       <FlowPane fx:id="tags" />
       <HBox>
-        <Label styleClass="cell_small_label" text="Phone Number: " />
+        <Label styleClass="cell_small_label" text="Phone Number: ">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       </HBox>
       <HBox>
-        <Label styleClass="cell_small_label" text="Next Contact Date: " />
+        <Label styleClass="cell_small_label" text="Next Contact Date: ">
+            <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="nextContactDate" styleClass="cell_small_label" text="\$nextContactDate" />
       </HBox>
       <HBox>
-        <Label styleClass="cell_small_label" text="Address: " />
+        <Label styleClass="cell_small_label" text="Address: ">
+            <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       </HBox>
       <HBox>
-        <Label styleClass="cell_small_label" text="Email: " />
+        <Label styleClass="cell_small_label" text="Email: ">
+            <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       </HBox>
       <HBox>
-        <Label styleClass="cell_small_label" text="Call Frequency (Days): " />
+        <Label styleClass="cell_small_label" text="Call Frequency (Days): ">
+            <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+            </minWidth>
+        </Label>
         <Label fx:id="callFrequency" styleClass="cell_small_label" text="\$callFrequency" />
       </HBox>
     </VBox>

--- a/src/test/java/seedu/address/model/contactrecord/ContactRecordTest.java
+++ b/src/test/java/seedu/address/model/contactrecord/ContactRecordTest.java
@@ -29,10 +29,21 @@ public class ContactRecordTest {
         assertFalse(ContactRecord.isValidContactRecord("2020-01-32"));
         assertFalse(ContactRecord.isValidContactRecord(""));
         assertFalse(ContactRecord.isValidContactRecord("2020-01-01 12:00"));
-        assertFalse(ContactRecord.isValidContactRecord(LocalDate.now().plusDays(1).toString()));
 
         // valid date in contact record
         assertTrue(ContactRecord.isValidContactRecord("2020-01-01"));
+    }
+
+    @Test
+    public void isCurrentOrPastDate() {
+        // future date
+        assertFalse(ContactRecord.isCurrentOrPastDate(LocalDate.now().plusDays(1)));
+
+        // current date
+        assertTrue(ContactRecord.isCurrentOrPastDate(LocalDate.now()));
+
+        // past date
+        assertTrue(ContactRecord.isCurrentOrPastDate(LocalDate.now().minusDays(1)));
     }
 
     @Test


### PR DESCRIPTION
Closes #139, Closes #141 

This PR adds:
1. Separate out date error message for when user types in an invalid date, and when a user types in a future date.
2. Make sure that NRIC and labels are always seen even if the content overflows
3. Add in duplicate detection feature into UG