### PR TITLE
Fix uncaught exception thrown

### DIFF
--- a/src/main/java/seedu/address/model/contactrecord/ContactRecord.java
+++ b/src/main/java/seedu/address/model/contactrecord/ContactRecord.java
@@ -14,9 +14,8 @@ import seedu.address.model.person.CallFrequency;
  * Guarantees: immutable; is valid as declared in {@link #isValidContactRecord(String)}
  */
 public class ContactRecord implements Comparable<ContactRecord> {
-    public static final String DATE_FORMAT = "yyyy-MM-dd";
     public static final String MESSAGE_CONSTRAINTS =
-            "Dates should be valid, and in the format of " + DATE_FORMAT;
+            "Dates should be valid, and in the format of YYYY-MM-DD";
     public static final String MESSAGE_CONSTRAINTS_FUTURE_DATE = "Dates should not be in the future";
     public final LocalDate value;
     private final String notes;
@@ -38,8 +37,7 @@ public class ContactRecord implements Comparable<ContactRecord> {
      */
     public static boolean isValidContactRecord(String testDate) {
         try {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
-            LocalDate.parse(testDate, formatter);
+            LocalDate.parse(testDate);
             return true;
         } catch (DateTimeParseException e) {
             return false;

--- a/src/main/java/seedu/address/model/contactrecord/ContactRecord.java
+++ b/src/main/java/seedu/address/model/contactrecord/ContactRecord.java
@@ -3,7 +3,6 @@ package seedu.address.model.contactrecord;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Objects;
 

--- a/src/test/java/seedu/address/model/contactrecord/ContactRecordTest.java
+++ b/src/test/java/seedu/address/model/contactrecord/ContactRecordTest.java
@@ -24,14 +24,26 @@ public class ContactRecordTest {
         // null tag contact date
         assertThrows(NullPointerException.class, () -> ContactRecord.isValidContactRecord(null));
 
-        // invalid date in contact record
-        assertFalse(ContactRecord.isValidContactRecord("2020-13-01"));
-        assertFalse(ContactRecord.isValidContactRecord("2020-01-32"));
-        assertFalse(ContactRecord.isValidContactRecord(""));
-        assertFalse(ContactRecord.isValidContactRecord("2020-01-01 12:00"));
-
         // valid date in contact record
         assertTrue(ContactRecord.isValidContactRecord("2020-01-01"));
+
+        // Invalid Month
+        assertFalse(ContactRecord.isValidContactRecord("2020-13-01"));
+
+        // Invalid Day
+        assertFalse(ContactRecord.isValidContactRecord("2020-01-32"));
+
+        // Invalid Day and Month
+        assertFalse(ContactRecord.isValidContactRecord("2020-13-32"));
+
+        // Empty String
+        assertFalse(ContactRecord.isValidContactRecord(""));
+
+        // Time in contact record
+        assertFalse(ContactRecord.isValidContactRecord("2020-01-01 12:00"));
+
+        // Non Leap year
+        assertFalse(ContactRecord.isValidContactRecord("2023-02-29"));
     }
 
     @Test


### PR DESCRIPTION
This is a bug as there will be an uncaught exception thrown by line `171` in the following code for some dates.

<img width="544" alt="image" src="https://github.com/user-attachments/assets/4ac46b05-26d4-4581-96aa-3bbb62782eb3">

This is because there is an error in the code, as the parser used different formatters (The one as stated above, and the one in `isValidContactRecord`), which led to the `LocalDate.parse` on line 171 throwing an exception that is not caught.

It is now changed to use the same formatter.

Closes #197 