### PR TITLE
Update UG and DG To Fix Dry Run Bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -301,6 +301,7 @@ The following activity diagram summarizes what happens when a user interacts wit
 
 ### NRIC Validation
 NRICs are stored in the `Nric` class. The method `Nric#isValidNric(String nric)` is used to validate the NRIC.
+
 #### Implementation
 The NRIC validation is done by checking if the NRIC is in the correct format, with this Regex pattern `"[STFG]\\d{7}[A-Z]"`.
 
@@ -315,10 +316,6 @@ Thereafter, the NRIC is checked for its validity using the checksum algorithm th
    * If the first letter is `F` or `G`: The checksum mapping is `0=X, 1=W, 2=U, 3=T, 4=R, 5=Q, 6=P, 7=N, 8=M, 9=L, 10=K`.
    * For example, if the remainder is `3` and the first letter is `S`, the checksum alphabet is `H`.
 6. Check if the last letter of the NRIC is the same as the checksum alphabet. If it is, the NRIC is valid, otherwise, it is invalid.
-
-<div markdown="span" class="alert alert-info">:information_source: **Note:** The checksum algorithm does not account for NRICs starting with `M`. However, as the NRICs in the context of ContactMate are only for Singaporeans and Permanent Residents, this is not an issue.
-
-</div>
 
 #### Future Improvements:
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -9,7 +9,7 @@ title: Developer Guide
 
 ## **Acknowledgements**
 
-* {list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well}
+* Based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -299,6 +299,27 @@ The following sequence diagram shows how the user can get previous command:
 The following activity diagram summarizes what happens when a user interacts with this feature:
 ![CommandTextHistoryActivityDiagram](images/CommandTextHistoryActivityDiagram.png)
 
+### NRIC Validation
+NRICs are stored in the `Nric` class. The method `Nric#isValidNric(String nric)` is used to validate the NRIC.
+#### Implementation
+The NRIC validation is done by checking if the NRIC is in the correct format, with this Regex pattern `"[STFG]\\d{7}[A-Z]"`.
+
+Thereafter, the NRIC is checked for its validity using the checksum algorithm that the Singapore Government uses. This algorithm is widely public and is as follows:
+
+1. Multiply each number in the NRIC by a weight. The mapping is as follows, in order, `2, 7, 6, 5, 4, 3, 2` (e.g. the weight of the first digit is `2`, that of the second digit is `7`)
+2. Sum up the products of the multiplication.
+3. If the first letter of the NRIC is `T` or `G`, add `4` to the sum.
+4. Get the remainder of the sum divided by `11`.
+5. Find the checksum alphabet based on this remainder to checksum mapping:
+   * If the first letter is `S` or `T`: The checksum mapping is `0=J, 1=Z, 2=I, 3=H, 4=G, 5=F, 6=E, 7=D, 8=C, 9=B, 10=A`.
+   * If the first letter is `F` or `G`: The checksum mapping is `0=X, 1=W, 2=U, 3=T, 4=R, 5=Q, 6=P, 7=N, 8=M, 9=L, 10=K`.
+   * For example, if the remainder is `3` and the first letter is `S`, the checksum alphabet is `H`.
+6. Check if the last letter of the NRIC is the same as the checksum alphabet. If it is, the NRIC is valid, otherwise, it is invalid.
+
+<div markdown="span" class="alert alert-info">:information_source: **Note:** The checksum algorithm does not account for NRICs starting with `M`. However, as the NRICs in the context of ContactMate are only for Singaporeans and Permanent Residents, this is not an issue.
+
+</div>
+
 #### Future Improvements:
 
 * Implement a feature to clear the command history.
@@ -575,13 +596,13 @@ Priorities: High (must have) - `****`, Medium (nice to have) - `***`, Low (unlik
 
 ### Non-Functional Requirements
 
-1. A user with above-average typing speed (> 40 WPM) for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
+1. A user with above-average typing speed (> 40 Words Per Minute) for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
 2. The product should be a single-user system.
 3. The product should not rely on a remote server.
 4. It should accommodate up to 250 elderly without performance slowdowns of more than 3 seconds during typical usage.
 5. The product should generally respond within two seconds.
 6. The product should work on Windows, Linux and Mac as long as they have `Java 17` installed.
-7. The product should not use a DBMS.
+7. The product should not use a Database Management System.
 8. The data should be stored locally and should be in a human editable text file.
 8. The product needs to be developed in a breadth-first incremental manner over the project duration.
 9. The software should follow the Object-oriented paradigm primarily.
@@ -598,6 +619,7 @@ Priorities: High (must have) - `****`, Medium (nice to have) - `***`, Low (unlik
 
 * **AAC**: Active Ageing Centre. A recreational centre that supports elderly in the area.
 * **Befriending Program**: Program which elderly signs up for to receive support from an AAC.
+* **AIC**: Agency for Integrated Care. A statutory board under the Ministry of Health in Singapore.
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -609,6 +631,14 @@ Given below are instructions to test the app manually. It is preferred to follow
 testers are expected to do more *exploratory* testing.
 
 </div>
+
+### Valid NRICs
+Here is a list of valid NRICs issued by the Singapore Government that can be used for testing:
+* S1486256J
+* S0919929B
+* S6516486H
+* T0500222I
+* T0251112B
 
 ### Launch and shutdown
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,7 +3,7 @@ layout: page
 title: User Guide
 ---
 
-ContactMate is a **desktop app for managing clients at Active Ageing Centres (AACs), optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, ContactMate can get your contact management tasks done faster than traditional GUI apps.
+ContactMate is a **desktop app for managing clients (Singaporeans and Permanent Residents) at Active Ageing Centres (AACs), optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, ContactMate can get your contact management tasks done faster than traditional GUI apps.
 
 * Table of Contents
 {:toc}
@@ -21,12 +21,7 @@ ContactMate is a **desktop app for managing clients at Active Ageing Centres (AA
          1. Hold down the `Command` key and press `Space` (<kbd>&#x2318; Cmd</kbd> + <kbd>Space</kbd>).
          2. Type `Terminal` and press `Enter`.
    1. In the terminal, type `java --version` and press `Enter`.
-   2. If you have Java `17` or above installed, you should see a message like this. Referencing the first line (`openjdk XX.0.12 2024-07-16 LTS`), `XX` should be `17` or above.
-    ```
-       openjdk 17.0.12 2024-07-16 LTS
-       OpenJDK Runtime Environment Corretto-17.0.12.7.1 (build 17.0.12+7-LTS)
-       OpenJDK 64-Bit Server VM Corretto-17.0.12.7.1 (build 17.0.12+7-LTS, mixed mode, sharing)
-      ```
+   2. If you have Java `17` or above installed, you should see a message containing something like this, (`openjdk XX.0.12 2024-07-16 LTS`), where `XX` should be `17` or above.
     3. If you do not have Java `17` or above installed, proceed to Step 2, otherwise, skip to Step 3.
 2. Install Java `17` using the following steps.
    1. Go to [this link](https://www.oracle.com/java/technologies/javase-jdk17-downloads.html).
@@ -75,7 +70,7 @@ ContactMate is a **desktop app for managing clients at Active Ageing Centres (AA
 
 Field | Description                                                                                                                                        | Constraints, Examples
 --------|----------------------------------------------------------------------------------------------------------------------------------------------------|------------------
-**NRIC** | National Registration Identity Card number of the elderly.                                                                                         | Valid, government issued NRIC. e.g., `S1803269D`
+**NRIC** | National Registration Identity Card number of the elderly.                                                                                         | Must be valid (i.e. issued by the Singapore Government). e.g., `S1803269D`
 **Name** | Name of the elderly.                                                                                                                               | Any word consisting only of alphabets, numbers or spaces. e.g., `John Doe`, `Alice`, `Bob`
 **Phone Number** | Phone number of the elderly.                                                                                                                       | Any number, 3 digits or longer. e.g., `98765432`, `91234567`
 **Email** | Email address of the elderly.                                                                                                                      | Any valid email address. e.g., `bob@gmail.com`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -247,7 +247,7 @@ Exits the program.
 Format: `exit`
 
 ### Navigating the Command History
-You are able to navigate through your command history (both valid and invalid commands) by using the up <kbd>&#8593;</kbd> and down <kbd>&#8595;</kbd> arrow keys.
+You are able to navigate through your command history (both valid and invalid commands) by using the up <kbd>&#8593;</kbd> and down <kbd>&#8595;</kbd> arrow keys. Before using the arrow keys, ensure that the command box is in focus (i.e. you have just clicked on the command box).
 
 ### Duplicate detection
 Duplicate entries (elderly) are entries with the same NRIC (case-insensitive). ContactMate will not allow duplicate entries, and will stop you from adding (`add`) or editing (`edit`) an elderly if it would result in a duplicate entry.
@@ -293,6 +293,9 @@ Furthermore, certain edits can cause ContactMate to behave in unexpected ways (e
 * **GUI (Graphical User Interface)**: A visual interface that enables users to interact with the system through graphical elements like buttons, menus, and icons.
 
 
+* **Command Box**: The text box in the GUI where you can type commands to interact with ContactMate.
+
+
 * **Index**: A number to used to identify a specific record (elderly) in the list. For instance, "1" refers to the first record in the list.
 
 
@@ -311,7 +314,7 @@ Furthermore, certain edits can cause ContactMate to behave in unexpected ways (e
 * **Profile View**: A display that shows all the details of a specific elderly.
 
 
-* **Person List View**: Also referred to as "`personList` view", this is the display that shows the list of elderly in ContactMate. By default, it is displayed when you start the application and is also displayed after using the `list` command.
+* **Person List View**: Also referred to as "`personList` view", this is the display that shows the list of elderly in ContactMate. By default, it is displayed when you start the application and is also displayed after using the `list` or `find` commands.
 
 --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #203, by specifying that AAC's only deal with Singaporeans and PRs
Closes #207, by adding in clarification to say Singapore Government in UG
Closes #199, by removing the whole thing, and using a more concise line
Closes #202, by making it clear that the focus must be on the command box before using arrow keys
Closes #237, Closes #238 by clarifying that `personList` view is also the result of `find`
Closes #243, by adding the implementation of validation of NRIC in DG

Also adds some sample NRICs in the manual testing section
